### PR TITLE
JSON nodes

### DIFF
--- a/src/certus/nodes/struct.py
+++ b/src/certus/nodes/struct.py
@@ -1,0 +1,33 @@
+"""Node models for structured outputs."""
+
+import dataclasses
+import typing
+
+from .core import Composite, NodeType
+
+
+@dataclasses.dataclass(kw_only=True)
+class Array(Composite):
+    """
+    Node representing a JSON array.
+
+    Parameters
+    ----------
+    elements : list of NodeType
+        Ordered child nodes representing the array elements.
+    """
+
+    elements: list[NodeType] = dataclasses.field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.children = self.elements
+        super().__post_init__()
+
+    def __getitem__(self, index: int) -> NodeType:
+        return self.elements[index]
+
+    def __len__(self) -> int:
+        return len(self.elements)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(elements={self.elements!r})"

--- a/src/certus/nodes/struct.py
+++ b/src/certus/nodes/struct.py
@@ -31,3 +31,44 @@ class Array(Composite):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(elements={self.elements!r})"
+
+
+@dataclasses.dataclass(kw_only=True)
+class Object(Composite):
+    """
+    Node representing a JSON object.
+
+    Parameters
+    ----------
+    fields : dict[str, NodeType]
+        Mapping from field names to child nodes.
+
+    Attributes
+    ----------
+    fields : dict[str, NodeType]
+        Stored mapping of field names to parsed nodes.
+    """
+
+    fields: dict[str, NodeType] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.children = list(self.fields.values())
+        super().__post_init__()
+
+    def __getitem__(self, key: str) -> NodeType:
+        return self.fields[key]
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(fields={self.fields!r})"
+
+    def keys(self) -> typing.KeysView[str]:
+        """Return the object's field keys."""
+        return self.fields.keys()
+
+    def items(self) -> typing.ItemsView[str, NodeType]:
+        """Return the object's (key, node) pairs."""
+        return self.fields.items()
+
+    def values(self) -> typing.ValuesView[NodeType]:
+        """Return the object's field values."""
+        return self.fields.values()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the `certus` package."""

--- a/tests/nodes/__init__.py
+++ b/tests/nodes/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the `certus.nodes` subpackage."""

--- a/tests/nodes/common.py
+++ b/tests/nodes/common.py
@@ -1,0 +1,13 @@
+"""Objects used among tests in this module."""
+
+import hypothesis.strategies as st
+
+from certus.nodes import Composite, Token
+
+ST_LOGPROBS = st.floats(max_value=0)
+ST_TOKEN_NODES = st.builds(Token, logprob=ST_LOGPROBS)
+ST_COMPOSITE_NODES = st.recursive(
+    ST_TOKEN_NODES,
+    lambda children: st.builds(Composite, children=st.lists(children, min_size=1, max_size=3)),
+    max_leaves=10,
+).filter(lambda n: isinstance(n, Composite))

--- a/tests/nodes/test_core.py
+++ b/tests/nodes/test_core.py
@@ -9,22 +9,13 @@ import pytest
 
 from certus.nodes import core
 
-ST_LOGPROBS = st.floats(max_value=0)
-ST_TOKEN_NODES = st.builds(core.Token, logprob=ST_LOGPROBS)
-
-ST_COMPOSITE_NODES = st.recursive(
-    ST_TOKEN_NODES,
-    lambda children: st.builds(
-        core.Composite, children=st.lists(children, min_size=1, max_size=3)
-    ),
-    max_leaves=10,
-).filter(lambda n: isinstance(n, core.Composite))
+from . import common
 
 ST_EMPTY_COMPOSITE_NODES = st.builds(core.Composite, children=st.just([]))
-ST_LEAF_LISTS = st.lists(ST_TOKEN_NODES, min_size=1)
+ST_LEAF_LISTS = st.lists(common.ST_TOKEN_NODES, min_size=1)
 
 
-@hyp.given(st.text(), ST_LOGPROBS)
+@hyp.given(st.text(), common.ST_LOGPROBS)
 def test_token_init(value, logprob):
     """Check a token is instantiated as expected."""
     token = core.Token(value, logprob)
@@ -34,7 +25,7 @@ def test_token_init(value, logprob):
     assert token._confidence is None
 
 
-@hyp.given(st.text(), ST_LOGPROBS)
+@hyp.given(st.text(), common.ST_LOGPROBS)
 def test_token_confidence_one_time(value, logprob):
     """
     Check a token calculates its confidence only once.
@@ -55,7 +46,7 @@ def test_token_confidence_one_time(value, logprob):
     clamp.assert_called_once_with(c1, 0.0, 1.0)
 
 
-@hyp.given(ST_COMPOSITE_NODES)
+@hyp.given(common.ST_COMPOSITE_NODES)
 def test_composite_node_init(composite):
     """Check a composite is instantiated as expected."""
     children = composite.children
@@ -143,7 +134,7 @@ def test_composite_node_leaves_one_time(composite, leaves):
     gather_leaves.assert_called_once_with(composite)
 
 
-@hyp.given(ST_COMPOSITE_NODES)
+@hyp.given(common.ST_COMPOSITE_NODES)
 def test_gather_leaves_composite_node(composite):
     """Check gathering from a composite returns a list of tokens."""
     leaves = core.gather_leaves(composite)
@@ -159,7 +150,7 @@ def test_gather_leaves_composite_node(composite):
     assert len(leaves) == _count_leaves(composite)
 
 
-@hyp.given(ST_TOKEN_NODES)
+@hyp.given(common.ST_TOKEN_NODES)
 def test_gather_leaves_solo_token_node(token):
     """Check gathering from a token returns itself in a list."""
     assert core.gather_leaves(token) == [token]

--- a/tests/nodes/test_struct.py
+++ b/tests/nodes/test_struct.py
@@ -1,0 +1,56 @@
+"""Tests for the `certus.nodes.struct` module."""
+
+import re
+
+import hypothesis as hyp
+import hypothesis.strategies as st
+
+from certus.nodes import struct
+
+from . import common
+
+ST_ARRAY_BASE_ELEMENT_LISTS = st.lists(common.ST_TOKEN_NODES | common.ST_COMPOSITE_NODES)
+
+
+def get_num_composites(node):
+    """Get the number of explicit composite nodes in a structure."""
+    if isinstance(node, common.Token):
+        return 0
+    
+    child_num = sum(get_num_composites(child) for child in node.children)
+    if isinstance(node, (struct.Array, struct.Object)):
+        return child_num
+
+    return child_num + 1
+
+
+@hyp.given(ST_ARRAY_BASE_ELEMENT_LISTS)
+def test_array_init_sets_children(elements):
+    """Check an array sets its children to be its elements."""
+    assert struct.Array(elements=elements).children == elements
+
+
+@hyp.given(ST_ARRAY_BASE_ELEMENT_LISTS.filter(len), st.data())
+def test_array_get_item(elements, data):
+    """Check you can get an element from an array with its index."""
+    idx = data.draw(st.integers(0, len(elements) - 1))
+    array = struct.Array(elements=elements)
+
+    assert array[idx] == elements[idx]
+
+
+@hyp.given(ST_ARRAY_BASE_ELEMENT_LISTS)
+def test_array_length(elements):
+    """Check the length of an array is the length of its elements."""
+    assert len(struct.Array(elements=elements)) == len(elements)
+
+
+@hyp.given(ST_ARRAY_BASE_ELEMENT_LISTS)
+def test_array_repr(elements):
+    """Check the representation of an array is as expected."""
+    array = struct.Array(elements=elements)
+    repr_ = repr(array)
+
+    assert isinstance(repr_, str)
+    assert re.match(r"Array\(elements=\[.*\]\)", repr_)
+    assert len(re.findall(r"children=", repr_)) == get_num_composites(array)

--- a/tests/nodes/test_struct.py
+++ b/tests/nodes/test_struct.py
@@ -1,6 +1,7 @@
 """Tests for the `certus.nodes.struct` module."""
 
 import re
+import string
 
 import hypothesis as hyp
 import hypothesis.strategies as st
@@ -9,14 +10,16 @@ from certus.nodes import struct
 
 from . import common
 
-ST_ARRAY_BASE_ELEMENT_LISTS = st.lists(common.ST_TOKEN_NODES | common.ST_COMPOSITE_NODES)
+ST_CORE_NODES = common.ST_TOKEN_NODES | common.ST_COMPOSITE_NODES
+ST_ARRAY_CORE_ELEMENT_LISTS = st.lists(ST_CORE_NODES)
+ST_OBJECT_CORE_FIELD_DICTS = st.dictionaries(st.text(string.ascii_lowercase + "_"), ST_CORE_NODES)
 
 
 def get_num_composites(node):
     """Get the number of explicit composite nodes in a structure."""
     if isinstance(node, common.Token):
         return 0
-    
+
     child_num = sum(get_num_composites(child) for child in node.children)
     if isinstance(node, (struct.Array, struct.Object)):
         return child_num
@@ -24,13 +27,13 @@ def get_num_composites(node):
     return child_num + 1
 
 
-@hyp.given(ST_ARRAY_BASE_ELEMENT_LISTS)
+@hyp.given(ST_ARRAY_CORE_ELEMENT_LISTS)
 def test_array_init_sets_children(elements):
     """Check an array sets its children to be its elements."""
     assert struct.Array(elements=elements).children == elements
 
 
-@hyp.given(ST_ARRAY_BASE_ELEMENT_LISTS.filter(len), st.data())
+@hyp.given(ST_ARRAY_CORE_ELEMENT_LISTS.filter(len), st.data())
 def test_array_get_item(elements, data):
     """Check you can get an element from an array with its index."""
     idx = data.draw(st.integers(0, len(elements) - 1))
@@ -39,13 +42,13 @@ def test_array_get_item(elements, data):
     assert array[idx] == elements[idx]
 
 
-@hyp.given(ST_ARRAY_BASE_ELEMENT_LISTS)
+@hyp.given(ST_ARRAY_CORE_ELEMENT_LISTS)
 def test_array_length(elements):
     """Check the length of an array is the length of its elements."""
     assert len(struct.Array(elements=elements)) == len(elements)
 
 
-@hyp.given(ST_ARRAY_BASE_ELEMENT_LISTS)
+@hyp.given(ST_ARRAY_CORE_ELEMENT_LISTS)
 def test_array_repr(elements):
     """Check the representation of an array is as expected."""
     array = struct.Array(elements=elements)
@@ -53,4 +56,42 @@ def test_array_repr(elements):
 
     assert isinstance(repr_, str)
     assert re.match(r"Array\(elements=\[.*\]\)", repr_)
+    assert all(repr(element) in repr_ for element in elements)
     assert len(re.findall(r"children=", repr_)) == get_num_composites(array)
+
+
+@hyp.given(ST_OBJECT_CORE_FIELD_DICTS)
+def test_object_sets_children(fields):
+    """Check an object sets its children to be its field-values."""
+    assert struct.Object(fields=fields).children == list(fields.values())
+
+
+@hyp.given(ST_OBJECT_CORE_FIELD_DICTS.filter(len), st.data())
+def test_object_get_item(fields, data):
+    """Check you can get a value from an object with its key."""
+    key = data.draw(st.sampled_from(list(fields.keys())))
+    object_ = struct.Object(fields=fields)
+
+    assert object_[key] == fields[key]
+
+
+@hyp.given(ST_OBJECT_CORE_FIELD_DICTS)
+def test_object_repr(fields):
+    """Check the representation of an object is as expected."""
+    object_ = struct.Object(fields=fields)
+    repr_ = repr(object_)
+
+    assert isinstance(repr_, str)
+    assert re.match(r"Object\(fields={.*}\)", repr_)
+    assert all([f"'{key}': {val!r}" in repr_ for key, val in fields.items()])
+    assert len(re.findall(r"children=", repr_)) == get_num_composites(object_)
+
+
+@hyp.given(ST_OBJECT_CORE_FIELD_DICTS.filter(len))
+def test_object_dict_views(fields):
+    """Check you can use dictionary views on object nodes."""
+    object_ = struct.Object(fields=fields)
+
+    assert object_.keys() == fields.keys()
+    assert object_.items() == fields.items()
+    assert list(object_.values()) == list(fields.values())  # dict_values don't support equality


### PR DESCRIPTION
Implement JSON-specific node types: `Array` and `Object`. These will be the building blocks of the structured output parser.