### PR TITLE
Improve `Composite.__repr__()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,34 +123,34 @@ Now, we can parse this dictionary response and token nodes into a single `Object
 >>> parsed = ct.parsers.parse_json(data, tokens)
 >>> parsed  # doctest:+SKIP
 Object(
-    fields={
-        'name': Composite(children=[Token(value=' "', logprob=-3e-05, start=8), Token(value='Henry', logprob=-7.2e-05, start=10), Token(value=' Wilde', logprob=-5.2e-05, start=15), Token(value='",', logprob=-0.000153, start=21)]), 
-        'age': Token(value='29', logprob=-7e-05, start=31),
-        'longest_walk_km': Composite(children=[Token(value='160', logprob=-0.000131, start=54), Token(value='.', logprob=-0.000229, start=57), Token(value='9', logprob=-0.000115, start=58)]),
-        'pets': Array(
-            elements=[
+  fields={
+    'name': Composite(value=' "Henry Wilde",', logprob=-0.000307, start=8),
+    'age': Token(value='29', logprob=-7e-05, start=31),
+    'longest_walk_km': Composite(value='165.2', logprob=-0.00047500000000000005, start=54),
+    'pets': Array(
+      elements=[
+        Object(
+          fields={
+            'name': Composite(value=' "Billie",', logprob=-0.000473, start=78),
+            'species': Composite(value=' "cat",', logprob=-0.000284, start=99),
+            'favourite_foods': Array(
+              elements=[
+                Composite(value=' ["fish",', logprob=-0.000454, start=125),
+                Composite(value=' "oat milk",', logprob=-0.00034, start=134),
                 Object(
-                    fields={
-                        'name': Composite(children=[Token(value=' "', logprob=-0.0002, start=78), Token(value='Bill', logprob=-3e-05, start=80), Token(value='ie', logprob=-0.000163, start=84), Token(value='",', logprob=-8e-05, start=86)]),
-                        'species': Composite(children=[Token(value=' "', logprob=-0.000174, start=99), Token(value='cat', logprob=-0.00011, start=101), Token(value='",', logprob=-0.0, start=104)]),
-                        'favourite_foods': Array(
-                            elements=[
-                                Composite(children=[Token(value=' ["', logprob=-8.4e-05, start=125), Token(value='fish', logprob=-2.7e-05, start=128), Token(value='",', logprob=-0.000343, start=132)]),
-                                Composite(children=[Token(value=' "', logprob=-0.000163, start=134), Token(value='o', logprob=-5.9e-05, start=136), Token(value='at', logprob=-8e-06, start=137), Token(value=' milk', logprob=-3.9e-05, start=139), Token(value='",', logprob=-7.1e-05, start=144)]), 
-                                Object(
-                                    fields={
-                                        'name': Composite(children=[Token(value=' "', logprob=-0.000123, start=155), Token(value='ch', logprob=-7.9e-05, start=157), Token(value='icken', logprob=-0.000168, start=159), Token(value='",', logprob=-7.8e-05, start=164)]),
-                                        'preparation': Composite(children=[Token(value=' "', logprob=-9.1e-05, start=181), Token(value='bo', logprob=-4.9e-05, start=183), Token(value='iled', logprob=-8.6e-05, start=185), Token(value='",', logprob=-3.4e-05, start=189)]),
-                                        'when_sick': Token(value=' true', logprob=-9e-06, start=204)
-                                    }
-                                )
-                            ]
-                        )
-                    }    
+                  fields={
+                    'name': Composite(value=' "chicken",', logprob=-0.000448, start=155),
+                    'preparation': Composite(value=' "boiled",', logprob=-0.00026000000000000003, start=181),
+                    'when_sick': Token(value=' true', logprob=-9e-06, start=204)
+                  }
                 )
-            ]
+              ]
+            )
+          }
         )
-    }
+      ]
+    )
+  }
 )
 
 ```

--- a/src/certus/nodes/core.py
+++ b/src/certus/nodes/core.py
@@ -33,7 +33,7 @@ class Token:
     logprob: float
     start: int
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self._confidence: float | None = None
 
     @property
@@ -75,12 +75,17 @@ class Composite:
 
     children: typing.Sequence[NodeType] = dataclasses.field(default_factory=list)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self._leaves: list[Token] | None = None
         self._value: str | None = None
         self._logprob: float | None = None
         self._start: int | None = None
         self._confidence: float | None = None
+
+    def __repr__(self) -> str:
+        value, logprob, start = self.value, self.logprob, self.start
+
+        return f"{self.__class__.__name__}({value=}, {logprob=}, {start=})"
 
     @property
     def value(self) -> str:

--- a/tests/nodes/test_core.py
+++ b/tests/nodes/test_core.py
@@ -1,6 +1,7 @@
 """Tests for the `certus.nodes.core` module."""
 
 import math
+import re
 from unittest import mock
 
 import hypothesis as hyp
@@ -58,6 +59,19 @@ def test_composite_node_init(composite):
     assert composite._start is None
     assert composite._confidence is None
     assert composite._leaves is None
+
+
+@hyp.given(common.ST_COMPOSITE_NODES, common.st_token_lists())
+def test_composite_node_repr(composite, leaves):
+    """Check a composite has a sensible string representation."""
+    with mock.patch.object(core, "gather_leaves", return_value=leaves) as gather_leaves:
+        repr_ = repr(composite)
+
+    assert isinstance(repr_, str)
+    assert re.match(r"Composite\(value=.*, logprob=.*, start=.*\)", repr_)
+    assert all(repr(getattr(composite, attr)) in repr_ for attr in ("value", "logprob", "start"))
+
+    gather_leaves.assert_called_once_with(composite)
 
 
 @hyp.given(ST_EMPTY_COMPOSITE_NODES, common.st_token_lists())

--- a/tests/nodes/test_struct.py
+++ b/tests/nodes/test_struct.py
@@ -6,25 +6,13 @@ import string
 import hypothesis as hyp
 import hypothesis.strategies as st
 
-from certus.nodes import Token, struct
+from certus.nodes import struct
 
 from . import common
 
 ST_CORE_NODES = common.st_tokens() | common.ST_COMPOSITE_NODES
 ST_ARRAY_CORE_ELEMENT_LISTS = st.lists(ST_CORE_NODES)
 ST_OBJECT_CORE_FIELD_DICTS = st.dictionaries(st.text(string.ascii_lowercase + "_"), ST_CORE_NODES)
-
-
-def get_num_composites(node):
-    """Get the number of explicit composite nodes in a structure."""
-    if isinstance(node, Token):
-        return 0
-
-    child_num = sum(get_num_composites(child) for child in node.children)
-    if isinstance(node, (struct.Array, struct.Object)):
-        return child_num
-
-    return child_num + 1
 
 
 @hyp.given(ST_ARRAY_CORE_ELEMENT_LISTS)
@@ -66,7 +54,6 @@ def test_array_repr(elements):
     assert isinstance(repr_, str)
     assert re.match(r"Array\(elements=\[.*\]\)", repr_)
     assert all(repr(element) in repr_ for element in elements)
-    assert len(re.findall(r"children=", repr_)) == get_num_composites(array)
 
 
 @hyp.given(ST_OBJECT_CORE_FIELD_DICTS)
@@ -93,7 +80,6 @@ def test_object_repr(fields):
     assert isinstance(repr_, str)
     assert re.match(r"Object\(fields={.*}\)", repr_)
     assert all([f"'{key}': {val!r}" in repr_ for key, val in fields.items()])
-    assert len(re.findall(r"children=", repr_)) == get_num_composites(object_)
 
 
 @hyp.given(ST_OBJECT_CORE_FIELD_DICTS.filter(len))


### PR DESCRIPTION
Fix #8 by adding a streamlined `repr` for the composite node class.